### PR TITLE
AR-160 Stout Logo Redirects to Stout website

### DIFF
--- a/__test__/__snapshots__/index.test.tsx.snap
+++ b/__test__/__snapshots__/index.test.tsx.snap
@@ -2319,6 +2319,28 @@ exports[`Verify Majors and Concentrations 3`] = `
 </body>
 `;
 
+exports[`Verify UW-Stout logo redirects to UW-Stout site 1`] = `
+<body>
+  <div>
+    <div
+      data-testid="test-root-element"
+    >
+      <a
+        data-testid="stout-logo-link"
+        href="https://www.uwstout.edu/"
+        target="_blank"
+      >
+        <img
+          alt="logo"
+          height="60"
+          src="/logo-new.svg"
+        />
+      </a>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`Verify adding completed course 1`] = `
 <body>
   <div>

--- a/__test__/index.test.tsx
+++ b/__test__/index.test.tsx
@@ -98,7 +98,6 @@ test("Verify UW-Stout logo redirects to UW-Stout site", async () => {
   expect(index.baseElement).toMatchSnapshot();
 
   const logo = screen.getByTestId("stout-logo-link");
-  //await user.click(logo);
   expect(logo).toHaveAttribute('href', 'https://www.uwstout.edu/');
   expect(logo).toHaveAttribute('target', '_blank');
 });

--- a/__test__/index.test.tsx
+++ b/__test__/index.test.tsx
@@ -2,7 +2,9 @@ import "@testing-library/jest-dom";
 import { screen, render as testRender } from "@testing-library/react";
 
 import Home from "../pages/index";
+import LogoLink from "../components/layout/LogoLink"
 import { setupUser, render } from "./util";
+import DefaultLayout from "../components/layout/DefaultLayout";
 
 test("Verify Majors and Concentrations", async () => {
   const user = setupUser();
@@ -88,4 +90,15 @@ test("Verify deleting completed course", async () => {
   const deleteButton = screen.getByTestId("delete-icon");
   await user.click(deleteButton);
   expect(screen.queryByText(/AEC-191/i)).toBeNull();
+});
+
+test("Verify UW-Stout logo redirects to UW-Stout site", async () => {
+  const user = setupUser();
+  const index = render(<LogoLink />)
+  expect(index.baseElement).toMatchSnapshot();
+
+  const logo = screen.getByTestId("stout-logo-link");
+  //await user.click(logo);
+  expect(logo).toHaveAttribute('href', 'https://www.uwstout.edu/');
+  expect(logo).toHaveAttribute('target', '_blank');
 });

--- a/components/layout/DefaultLayout.tsx
+++ b/components/layout/DefaultLayout.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import { Button } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import IconButton from "@mui/material/IconButton";
+import LogoLink from "./LogoLink";
 export default function DefaultLayout(props: {
   children: JSX.Element | JSX.Element[];
 }): JSX.Element {
@@ -15,7 +16,7 @@ export default function DefaultLayout(props: {
     <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
       <MenuIcon />
     </IconButton>
-    <img src="/logo-new.svg" height="60" alt="logo" />
+   <LogoLink/>
     <Typography variant="h5" component="div" sx={{ flexGrow: 1 }}/>
     <Button color="inherit">Login</Button>
     </Toolbar>

--- a/components/layout/LogoLink.tsx
+++ b/components/layout/LogoLink.tsx
@@ -1,7 +1,7 @@
 export default function LogoLink(): JSX.Element {
-    return (
-        <a href="https://www.uwstout.edu/" target="_blank" data-testid="stout-logo-link">
-            <img src="/logo-new.svg" height="60" alt="logo" />
-        </a>
-    )
+  return (
+    <a href="https://www.uwstout.edu/" target="_blank" data-testid="stout-logo-link">
+      <img src="/logo-new.svg" height="60" alt="logo" />
+    </a>
+  )
 };

--- a/components/layout/LogoLink.tsx
+++ b/components/layout/LogoLink.tsx
@@ -1,0 +1,7 @@
+export default function LogoLink(): JSX.Element {
+    return (
+        <a href="https://www.uwstout.edu/" target="_blank" data-testid="stout-logo-link">
+            <img src="/logo-new.svg" height="60" alt="logo" />
+        </a>
+    )
+};


### PR DESCRIPTION
# Jira Ticket

[AR-160 Logo Redirects](https://academic-cs458.atlassian.net/browse/AR-160)


# Description of Changes
When you click on the Stout Logo you will now be redirected to the Stout Home Page in a new tab.

# Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Feature Update

# How has this been tested?
Tested Via Jest

**Automated Tests (Preferred)**
- [X] Test: index.test.tsx - Line 95-104: Test the ability to click the UW-Stout logo and if it redirects the user

**Manual Tests**
NA

# Checklist
- [x] My code follows ES Lint guidelines
- [X] My solution meets all of the acceptance criteria for the user story
- [X] My code contains necessary comments and documentation
- [X] I have added tests that are useful and cover the new changes
- [X] New and existing unit tests pass locally
